### PR TITLE
Add linux/riscv64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ build-linux: clean fmt
 		go build -ldflags "$(LDFLAGS)" -o _releases/$(NAME)-linux-amd64
 	GOOS=linux GOARCH=arm64 \
 		go build -ldflags "$(LDFLAGS)" -o _releases/$(NAME)-linux-arm64
+	GOOS=linux GOARCH=riscv64 \
+		go build -ldflags "$(LDFLAGS)" -o _releases/$(NAME)-linux-riscv64
 
 build-darwin: clean fmt
 	GOOS=darwin GOARCH=amd64 \


### PR DESCRIPTION
This PR adds RISC-V builds to the project.

Looking at the [recent](https://github.com/jitsi/docker-jitsi-meet/pull/1269/) work on allowing to run jitsi on other architectures than amd64 on Docker, I see adding riscv64 support to this project as one step towards jitsi on Docker to run on riscv64.

Golang supports riscv64 since a few years back, cross-compiling works just like any other arch. Using the riscv64 build using the provided test in the readme also works without any problems.

```shell
$  _releases/tpl-linux-riscv64 sample.txt
Hello ubuntu
```
(build with go version go1.17 linux/riscv64) on Ubuntu Server 21.10, Linux 5.13.0-1020-generic.

RISC-V is an open standard instruction set architecture, which is under rapid development. Distributions including AOSP, Arch Linux, Debian, Gentoo Linux, Fedora, OpenEuler, etc are also actively doing porting work for this architecture.
