### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   build-deploy:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492  # v2
       with:
         go-version: '1.22'
     - name: Build
@@ -21,7 +21,7 @@ jobs:
         go version
         make build-all
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         generate_release_notes: true


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).